### PR TITLE
Adopt Spring Cloud Gateway and Consul on the Server side to register services

### DIFF
--- a/cloud-payment/docker-compose.yml
+++ b/cloud-payment/docker-compose.yml
@@ -40,6 +40,24 @@ services:
       - message-rpc-server
     networks:
       - message-network
+  gateway-service:
+    image: docker.io/nanachi1027/gateway-service:latest  # Use docker.io/nanachi1027 for the image
+    container_name: gateway-service
+    ports:
+      - "9994:9994"  # Expose the gateway service to external world
+    environment:
+      SPRING_PROFILES_ACTIVE: "docker"
+      SPRING_CLOUD_GATEWAY_DISCOVERY_LOCATOR_ENABLED: "true"
+      SPRING_CLOUD_GATEWAY_ROUTES_0_URI: "lb://RPC-SERVER"
+      SPRING_CLOUD_GATEWAY_ROUTES_0_PATH: "/rpc/server/**"
+      SPRING_CLOUD_GATEWAY_ROUTES_1_URI: "lb://RPC-CLIENT"
+      SPRING_CLOUD_GATEWAY_ROUTES_1_PATH: "/rpc/client/**"
+    depends_on:
+      - message-rpc-server  # Ensure the rpc server is available before starting the gateway
+      - activemq
+      - zipkin
+    networks:
+      - message-network
 
   mysql:
     image: mysql:8.0

--- a/cloud-payment/gateway-service/pom.xml
+++ b/cloud-payment/gateway-service/pom.xml
@@ -9,87 +9,29 @@
         <version>1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>message-rpc-server</artifactId>
+    <artifactId>gateway-service</artifactId>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <app.image.name>message-rpc-server</app.image.name>
+        <app.image.name>gateway-service</app.image.name>
         <app.image.tag>1.0.0</app.image.tag>
     </properties>
 
-
     <dependencies>
         <dependency>
-            <groupId>com.cloud.payment</groupId>
-            <artifactId>message-service-facade</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-actuator</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-tracing-bridge-brave</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>net.devh</groupId>
-            <artifactId>grpc-server-spring-boot-starter</artifactId>
-            <version>2.13.1.RELEASE</version>
-        </dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-protobuf</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-webflux</artifactId>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-gateway</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-consul-discovery</artifactId>
+            <artifactId>spring-cloud-starter-loadbalancer</artifactId>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring-boot.version}</version>
-                <configuration>
-                    <mainClass>com.example.grpc.server.GrpcServerMain</mainClass>
-                    <layout>JAR</layout>
-                    <excludes>
-                        <exclude>
-                            <groupId>org.projectlombok</groupId>
-                            <artifactId>lombok</artifactId>
-                        </exclude>
-                    </excludes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>repackage</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 
-
-    <!-- profiles -->
     <profiles>
-        <!-- Profile for building Spring Boot application and creating Docker images -->
+        <!-- Normal profile for compiling Maven JAR file -->
         <profile>
             <id>spring-boot-build</id>
             <activation>
@@ -104,8 +46,7 @@
                 </plugins>
             </build>
         </profile>
-
-        <!-- Profile for pushing gRPC Server image to local docker registry -->
+        <!-- Profile for pushing Docker image to local Docker repository -->
         <profile>
             <id>jib-push-to-local</id>
             <activation>
@@ -120,48 +61,41 @@
                             <from>
                                 <image>openjdk:17</image>
                             </from>
+                            <to>
+                                <image>localhost:5000/${app.image.name}:${app.image.tag}</image>
+                                <auth>
+                                    <!--suppress UnresolvedMavenProperty -->
+                                    <username>${env.DOCKER_LOCAL_USERNAME}</username>
+                                    <!--suppress UnresolvedMavenProperty -->
+                                    <password>${env.DOCKER_LOCAL_ACCESS_TOKEN}</password>
+                                </auth>
+                            </to>
                             <container>
                                 <ports>
-                                    <port>8581</port>  <!-- gRPC Server -->
-                                    <port>59081</port> <!-- gRPC Communication -->
+                                    <port>9994</port>
                                 </ports>
                                 <format>OCI</format>
                             </container>
                         </configuration>
                         <executions>
-                            <!-- Push with custom tag -->
                             <execution>
-                                <id>push-custom-tag</id>
+                                <id>push-with-tag</id>
                                 <phase>package</phase>
                                 <configuration>
                                     <to>
                                         <image>docker.io/nanachi1027/${app.image.name}:${app.image.tag}</image>
-                                        <auth>
-                                            <!--suppress UnresolvedMavenProperty -->
-                                            <username>${env.DOCKER_HUB_USERNAME}</username>
-                                            <!--suppress UnresolvedMavenProperty -->
-                                            <password>${env.DOCKER_HUB_ACCESS_TOKEN}</password>
-                                        </auth>
                                     </to>
                                 </configuration>
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
                             </execution>
-
-                            <!-- Push with 'latest' tag -->
                             <execution>
                                 <id>push-latest-tag</id>
                                 <phase>package</phase>
                                 <configuration>
                                     <to>
-                                        <image>docker.io/nanachi1027/${app.image.name}:${app.image.tag}</image>
-                                        <auth>
-                                            <!--suppress UnresolvedMavenProperty -->
-                                            <username>${env.DOCKER_HUB_USERNAME}</username>
-                                            <!--suppress UnresolvedMavenProperty -->
-                                            <password>${env.DOCKER_HUB_ACCESS_TOKEN}</password>
-                                        </auth>
+                                        <image>docker.io/nanachi1027/${app.image.name}:latest</image>
                                     </to>
                                 </configuration>
                                 <goals>
@@ -174,7 +108,7 @@
             </build>
         </profile>
 
-        <!-- Profile for pushing gRPC Server image to Docker Hub -->
+        <!-- Profile for pushing Docker image to Docker Hub -->
         <profile>
             <id>jib-push-to-dockerhub</id>
             <activation>
@@ -189,28 +123,29 @@
                             <from>
                                 <image>openjdk:17</image>
                             </from>
+                            <to>
+                                <image>docker.io/nanachi1027/${app.image.name}:${app.image.tag}</image>
+                                <auth>
+                                    <!--suppress UnresolvedMavenProperty -->
+                                    <username>${env.DOCKER_HUB_USERNAME}</username>
+                                    <!--suppress UnresolvedMavenProperty -->
+                                    <password>${env.DOCKER_HUB_ACCESS_TOKEN}</password>
+                                </auth>
+                            </to>
                             <container>
                                 <ports>
-                                    <port>8581</port>  <!-- Web Server -->
-                                    <port>59081</port> <!-- gRPC Service -->
+                                    <port>9994</port>
                                 </ports>
                                 <format>OCI</format>
                             </container>
                         </configuration>
                         <executions>
                             <execution>
-                                <id>push-custom-tag</id>
+                                <id>push-with-tag</id>
                                 <phase>package</phase>
                                 <configuration>
                                     <to>
-                                        <!--suppress UnresolvedMavenProperty -->
                                         <image>docker.io/nanachi1027/${app.image.name}:${app.image.tag}</image>
-                                        <auth>
-                                            <!--suppress UnresolvedMavenProperty -->
-                                            <username>${env.DOCKER_HUB_USERNAME}</username>
-                                            <!--suppress UnresolvedMavenProperty -->
-                                            <password>${env.DOCKER_HUB_ACCESS_TOKEN}</password>
-                                        </auth>
                                     </to>
                                 </configuration>
                                 <goals>
@@ -222,14 +157,7 @@
                                 <phase>package</phase>
                                 <configuration>
                                     <to>
-                                        <!--suppress UnresolvedMavenProperty -->
                                         <image>docker.io/nanachi1027/${app.image.name}:latest</image>
-                                        <auth>
-                                            <!--suppress UnresolvedMavenProperty -->
-                                            <username>${env.DOCKER_HUB_USERNAME}</username>
-                                            <!--suppress UnresolvedMavenProperty -->
-                                            <password>${env.DOCKER_HUB_ACCESS_TOKEN}</password>
-                                        </auth>
                                     </to>
                                 </configuration>
                                 <goals>
@@ -241,6 +169,6 @@
                 </plugins>
             </build>
         </profile>
-
     </profiles>
+
 </project>

--- a/cloud-payment/gateway-service/src/main/java/com/cloud/payment/gateway/GatewayServiceApplication.java
+++ b/cloud-payment/gateway-service/src/main/java/com/cloud/payment/gateway/GatewayServiceApplication.java
@@ -1,0 +1,11 @@
+package com.cloud.payment.gateway;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class GatewayServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(GatewayServiceApplication.class, args);
+    }
+}

--- a/cloud-payment/gateway-service/src/main/java/com/cloud/payment/gateway/controller/FacadeController.java
+++ b/cloud-payment/gateway-service/src/main/java/com/cloud/payment/gateway/controller/FacadeController.java
@@ -1,0 +1,15 @@
+package com.cloud.payment.gateway.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/facade")
+public class FacadeController {
+    @GetMapping("/status")
+    public ResponseEntity<String> getStatus() {
+        return ResponseEntity.ok("Success");
+    }
+}

--- a/cloud-payment/gateway-service/src/main/resources/application.yml
+++ b/cloud-payment/gateway-service/src/main/resources/application.yml
@@ -1,0 +1,23 @@
+server:
+  port: 9994
+
+spring:
+  cloud:
+    gateway:
+      discovery:
+        locator:
+          enabled: true
+          lower-case-service-id: true
+      routes:
+        - id: rpc-server
+          uri: lb://RPC-SERVER
+          predicates:
+            - Path=/rpc/server/**
+          filters:
+            - StripPrefix=1
+        - id: rpc-client
+          uri: lb://RPC-CLIENT
+          predicates:
+            - Path=/rpc/client/**
+          filters:
+            - StripPrefix=1

--- a/cloud-payment/message-rpc-server/src/main/resources/application.yml
+++ b/cloud-payment/message-rpc-server/src/main/resources/application.yml
@@ -1,6 +1,13 @@
 spring:
+  cloud:
+    consul:
+      host: localhost
+      port: 59081
+      discovery:
+        register: true
+        service-name: message-service
   application:
-    name: grpc-server
+    name: message-rpc-server
   lifecycle:
     timeout-per-shutdown-phase: "2m"
   main:
@@ -13,7 +20,7 @@ server:
 
 grpc:
   server:
-    address: localhost
+    address: 0.0.0.0
     port: 59081
 
 management:

--- a/cloud-payment/message-web/src/main/resources/application.yml
+++ b/cloud-payment/message-web/src/main/resources/application.yml
@@ -3,7 +3,7 @@ server:
 
 spring:
   application:
-    name: grpc-web-client
+    name: message-web
   webflux:
     client:
       response-timeout: 30s
@@ -15,8 +15,8 @@ spring:
 
 grpc-client:
   message-service:
-    host: localhost
-    port: 59081
+    host: gateway-service # Use gateway instead of direct connection
+    port: 9994 # gateway's port
 
 management:
   health:

--- a/cloud-payment/pom.xml
+++ b/cloud-payment/pom.xml
@@ -13,6 +13,7 @@
         <module>message-rpc-server</module>
         <module>message-web</module>
         <module>common-core</module>
+        <module>gateway-service</module>
     </modules>
 
     <properties>
@@ -90,6 +91,13 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-resolver-dns-native-macos</artifactId>
                 <version>4.1.68.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>2024.0.1</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
In this commit, we focus on integrating Spring Cloud Gateway for service discovery, enabling client-side service lookup and server-side service registration. We also adopt Consul on the server side to detect services and register them with the gateway.

Integrating Spring Cloud Gateway for gRPC Routing & Load Balancing #38